### PR TITLE
Add Support for WordPress Bedrock Path in WordPress.php 

### DIFF
--- a/classes/WordPress.php
+++ b/classes/WordPress.php
@@ -60,6 +60,10 @@ class WordPress {
             if (file_exists($path)) {
                 return $path;
             }
+            $wpPath = $dir . '/wp/wp-load.php';
+            if (file_exists($wpPath)) {
+                return $wpPath;
+            }
             $parent = dirname($dir);
             if ($parent == $dir) {
                 break;


### PR DESCRIPTION
This PR updates the `findWPLoad` function in `WordPress.php` to support WordPress Bedrock installations. It now checks within the `wp/` subdirectory for `wp-load.php`, resolving fatal errors in Bedrock setups.

**References:**
- [WordPress Bedrock by Roots](https://roots.io/bedrock/)